### PR TITLE
chore: include `README.md` & `CHANGELOG.md` in published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"./package.json": "./package.json"
 	},
 	"files": [
+		"README.md",
+		"CHANGELOG.md",
 		"/dist",
 		"/src",
 		"!**/__tests__"


### PR DESCRIPTION
Closes #44 


## Type of change
Updated the `files` property in the `package.json`

## Details
As asked in the [issue](https://github.com/StyleShit/create-typescript-package/issues/44),  I had to make necessary changes into the `files`  property of the `package.json` file 

### Before update 
`files` property of `package.json`:-

```
"files": [
		"/dist",
		"/src",
		"!**/__tests__"
	],
```

### After update 
`files` property of `package.json`:-
```
"files": [
		"README.md",
		"CHANGELOG.md",
		"/dist",
		"/src",
		"!**/__tests__"
	],
```

@StyleShit  please review this pull request and merge it to solve the issue #44 