### PR TITLE
chore: delete unused vscode `settings.json` file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"eslint.experimental.useFlatConfig": true
-}


### PR DESCRIPTION
## Type of change
Deleted the settings.json in the .vscode folder

## Details
As asked in the [issue](https://github.com/StyleShit/create-typescript-package/issues/43),  I had to make necessary changes into the .vscode folder.

The vscode-eslint version was greater than v3.0.10, which was specified in the the eslint [[docs](https://eslint.org/docs/latest/use/configure/migration-guide#visual-studio-code-support).] 

So, it was safe to delete the settings.json file.

@StyleShit please review this pull request and merge it to solve the issue #43 